### PR TITLE
Update version regex to match other version numbers

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -40,7 +40,7 @@ async function getGhidraVersionInfo(): Promise<Dict> {
   ).readBody();
 
   // parse Ghidra version numbre and archive name
-  const ptn = /<td>(\d\.\d\.\d)<\/td>\r\n.*<a href=\"(ghidra_.*?_PUBLIC_\d{8}\.zip)\">/gi;
+  const ptn = /<td>(\d+\.\d+(?:\.\d+)?)<\/td>\r\n.*<a href=\"(ghidra_.*?_PUBLIC_\d{8}\.zip)\">/gi;
   let m;
   let versionInfo: Dict = {};
   while ((m = ptn.exec(releaseNoteHTML)) !== null) {


### PR DESCRIPTION
Some version numbers for Ghidra don't have 3 parts, only 2.

Will match versions `9.0` and `9.1` as well as `9.0.1`, `9.1.2`, etc.