### PR TITLE
Bump node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: ""
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "code"


### PR DESCRIPTION
This fixes the following warning:

> build
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: er28-0652/setup-ghidra@master. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.